### PR TITLE
Change import EventEmitter.

### DIFF
--- a/src/components/Liveview.ts
+++ b/src/components/Liveview.ts
@@ -1,4 +1,4 @@
-import * as EventEmitter from "events";
+import {EventEmitter} from "events";
 import * as fs from "fs";
 import {Camera} from "./Camera";
 import {ICloseable, ILiveviewOptions} from "../interfaces";


### PR DESCRIPTION
Correct bug with Typescript 3.5.3:
Type 'typeof internal' is not a constructor function type.

No need to update the typescript of the lib.